### PR TITLE
Fix:update version of pages action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
          # Run a build step here if your project requires
 
          - name: Publish to Cloudflare Pages
-           uses: cloudflare/pages-action@1
+           uses: cloudflare/pages-action@v1.0.0
            with:
              apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
              accountId: YOUR_ACCOUNT_ID


### PR DESCRIPTION
using cloudflare/pages-action@1.0.0 creates an error in the action. While cloudflare/pages-action@v1.0.0 works as expected.

![Screenshot 2022-05-12 at 12 29 31](https://user-images.githubusercontent.com/35943047/168064959-00266e3a-b938-4423-a529-9a6186766246.png)
