### PR TITLE
Add support for specifying branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ To generate an API token:
 7. Select Continue to summary > Create Token.
 
 More information can be found on [our guide for making Direct Upload deployments with continous integration](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#use-github-actions).
+
+### Specifying a branch
+The branch name is used by Cloudflare Pages to determine if the deployment is production or preview. Read more about
+[git branch build controls](https://developers.cloudflare.com/pages/platform/branch-build-controls/#branch-build-controls).
+
+If you are in a Git workspace, Wrangler will automatically pull the branch information for you. You can override this
+manually by adding the argument `branch: YOUR_BRANCH_NAME`.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: true
+  branch:
+    description: "The name of the branch you want to deploy to"
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -16115,6 +16115,7 @@ try {
   const projectName = (0, import_core.getInput)("projectName", { required: true });
   const directory = (0, import_core.getInput)("directory", { required: true });
   const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: true });
+  const branch = (0, import_core.getInput)("branch", { required: false });
   const octokit = (0, import_github.getOctokit)(gitHubToken);
   const createPagesDeployment = async () => {
     await esm_default`
@@ -16123,7 +16124,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
     const response = await (0, import_undici.fetch)(`https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`, { headers: { Authorization: `Bearer ${apiToken}` } });
     const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ try {
   const projectName = getInput("projectName", { required: true });
   const directory = getInput("directory", { required: true });
   const gitHubToken = getInput("gitHubToken", { required: true });
+  const branch = getInput("branch", { required: false });
 
   const octokit = getOctokit(gitHubToken);
 
@@ -64,7 +65,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}"
+    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
 
     const response = await fetch(


### PR DESCRIPTION
As a user, I would like to provide my own logic to determine which deployments go to production and which go to preview. Adding support to specify the branch name gives me that flexibility since the branch name is used by Cloudflare Pages to determine if the deployment is production or preview.

In this PR, we have added the parameter `branch` that is passed directly to wranger2. Wrangler2 handles the situation when the [branch is empty](https://github.com/cloudflare/wrangler2/blob/73af915394db023c2a9565805cc6b53fd6b9ee49/packages/wrangler/src/pages/publish.tsx#L224), so no additional checks are needed.

Since this is an optional parameter, documentation is added as an aside. 

This closes https://github.com/cloudflare/pages-action/issues/11 https://github.com/cloudflare/pages-action/issues/12