### PR TITLE
Make `gitHubToken` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              accountId: YOUR_ACCOUNT_ID
              projectName: YOUR_PROJECT_NAME
              directory: YOUR_ASSET_DIRECTORY
+             # Optional, if you want to create a deployment showing the status on your GitHub repo
              gitHubToken: ${{ secrets.GITHUB_TOKEN }}
    ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
   gitHubToken:
     description: "GitHub Token"
-    required: true
+    required: false
   branch:
     description: "The name of the branch you want to deploy to"
     required: false

--- a/index.js
+++ b/index.js
@@ -16114,9 +16114,9 @@ try {
   const accountId = (0, import_core.getInput)("accountId", { required: true });
   const projectName = (0, import_core.getInput)("projectName", { required: true });
   const directory = (0, import_core.getInput)("directory", { required: true });
-  const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: true });
+  const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: false });
   const branch = (0, import_core.getInput)("branch", { required: false });
-  const octokit = (0, import_github.getOctokit)(gitHubToken);
+  const octokit = gitHubToken && (0, import_github.getOctokit)(gitHubToken);
   const createPagesDeployment = async () => {
     await esm_default`
     $ export CLOUDFLARE_API_TOKEN="${apiToken}"
@@ -16164,7 +16164,7 @@ try {
     });
   };
   (async () => {
-    const gitHubDeployment = await createGitHubDeployment();
+    const gitHubDeployment = octokit && await createGitHubDeployment();
     const pagesDeployment = await createPagesDeployment();
     (0, import_core.setOutput)("id", pagesDeployment.id);
     (0, import_core.setOutput)("url", pagesDeployment.url);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,10 +52,10 @@ try {
   const accountId = getInput("accountId", { required: true });
   const projectName = getInput("projectName", { required: true });
   const directory = getInput("directory", { required: true });
-  const gitHubToken = getInput("gitHubToken", { required: true });
+  const gitHubToken = getInput("gitHubToken", { required: false });
   const branch = getInput("branch", { required: false });
 
-  const octokit = getOctokit(gitHubToken);
+  const octokit = gitHubToken && getOctokit(gitHubToken);
 
   const createPagesDeployment = async () => {
     // TODO: Replace this with an API call to wrangler so we can get back a full deployment response object
@@ -120,7 +120,7 @@ try {
   };
 
   (async () => {
-    const gitHubDeployment = await createGitHubDeployment();
+    const gitHubDeployment = octokit && await createGitHubDeployment();
 
     const pagesDeployment = await createPagesDeployment();
 


### PR DESCRIPTION
We don't always want a deployment status on the GitHub repo, so I want to make the `gitHubToken` input optional.