### PR TITLE
Tag vX major when we do a release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,11 @@
+name: Tag major release (vX)
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest


### PR DESCRIPTION
When do a release like 1.1 this will automatically update the v1 tag to point towards that commit

Closes #38