### PR TITLE
Ensure that existing GitHub deployments do not become inactive

### DIFF
--- a/index.js
+++ b/index.js
@@ -22125,7 +22125,8 @@ try {
       production_environment: productionEnvironment,
       log_url: `https://dash.cloudflare.com/${accountId}/pages/view/${projectName}/${deploymentId}`,
       description: "Cloudflare Pages",
-      state: "success"
+      state: "success",
+      auto_inactive: false
     });
   };
   const createJobSummary = async ({ deployment, aliasUrl }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ try {
 			log_url: `https://dash.cloudflare.com/${accountId}/pages/view/${projectName}/${deploymentId}`,
 			description: "Cloudflare Pages",
 			state: "success",
+			auto_inactive: false
 		});
 	};
 


### PR DESCRIPTION
Since Cloudflare Pages retains previous preview deployments, they shouldn't be marked as inactive on GitHub when a new one is created.