### PR TITLE
Fix branch name for `pull_request` events

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
   branch:
     description: "The name of the branch you want to deploy to"
     required: false
+    default: "${{ github.head_ref || github.ref_name }}"
   workingDirectory:
     description: "The working directory in which to run Wrangler"
     required: false

--- a/index.js
+++ b/index.js
@@ -21114,12 +21114,12 @@ var __publicField2 = (obj, key, value) => {
 var Shell = class {
   constructor(env_passthrough = ["PATH"]) {
     __publicField(this, "process");
-    const env2 = { PS1: "" };
+    const env = { PS1: "" };
     env_passthrough.forEach((key) => {
-      env2[key] = process.env[key];
+      env[key] = process.env[key];
     });
     this.process = import_child_process.default.spawn("bash", ["--noprofile", "--norc"], {
-      env: env2,
+      env,
       detached: true
     });
     this.process.stdout.setEncoding("utf8");
@@ -22059,7 +22059,6 @@ var src_default = shellac;
 
 // src/index.ts
 var import_undici = __toESM(require_undici());
-var import_process = require("process");
 var import_node_path = __toESM(require("path"));
 try {
   const apiToken = (0, import_core.getInput)("apiToken", { required: true });
@@ -22099,7 +22098,7 @@ try {
     const deployment = await octokit.rest.repos.createDeployment({
       owner: import_github.context.repo.owner,
       repo: import_github.context.repo.repo,
-      ref: import_github.context.ref,
+      ref: branch,
       auto_merge: false,
       description: "Cloudflare Pages",
       required_contexts: [],
@@ -22155,8 +22154,7 @@ try {
     const project = await getProject();
     if (!project)
       throw new Error("Unable to find pages project");
-    const githubBranch = import_process.env.GITHUB_REF_NAME;
-    const productionEnvironment = githubBranch === project.production_branch;
+    const productionEnvironment = branch === project.production_branch;
     const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
     let gitHubDeployment;
     if (gitHubToken && gitHubToken.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ try {
 		const deployment = await octokit.rest.repos.createDeployment({
 			owner: context.repo.owner,
 			repo: context.repo.repo,
-			ref: context.ref,
+			ref: branch,
 			auto_merge: false,
 			description: "Cloudflare Pages",
 			required_contexts: [],
@@ -124,8 +124,7 @@ try {
 		const project = await getProject();
 		if (!project) throw new Error("Unable to find pages project");
 
-		const githubBranch = env.GITHUB_REF_NAME;
-		const productionEnvironment = githubBranch === project.production_branch;
+		const productionEnvironment = branch === project.production_branch;
 		const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
 
 		let gitHubDeployment: Awaited<ReturnType<typeof createGitHubDeployment>>;


### PR DESCRIPTION
Closes #22 by using the correct branch name for `pull_request` events, which causes the branch name (instead of `HEAD`) to appear in the Cloudflare dashboard as expected:

![image](https://user-images.githubusercontent.com/1505561/214847307-8bb685e3-f393-48ff-b703-ee58e7c6ba2c.png)

---

Also closes #39 (which is a duplicate of the second half of #22) by mapping GitHub deployments to the correct PR branch name, which causes deployments to start appearing in GitHub PRs as expected:

![image](https://user-images.githubusercontent.com/1505561/214847139-2dfbbdbf-047c-4392-b77d-4bc3b7c70b27.png)