### PR TITLE
Added clarity for branch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              directory: YOUR_ASSET_DIRECTORY
              # Optional: Enable this if you want to have GitHub Deployments triggered
              gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+             # Optional: Set a branch name to override the current branch name
+             branch: YOUR_BRANCH_NAME
    ```
 
 1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_ASSET_DIRECTORY` with the appropriate values to your Pages project.
@@ -64,6 +66,8 @@ The branch name is used by Cloudflare Pages to determine if the deployment is pr
 
 If you are in a Git workspace, Wrangler will automatically pull the branch information for you. You can override this
 manually by adding the argument `branch: YOUR_BRANCH_NAME`.
+
+When using a branch other than `main` for your production branch, you must set `branch: main` in your workflow to ensure that the deployment is published to the production environment.
 
 ### Specifying a working directory
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To generate an API token:
 6. Under Permissions, select Account, Cloudflare Pages and Edit:
 7. Select Continue to summary > Create Token.
 
-More information can be found on [our guide for making Direct Upload deployments with continous integration](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#use-github-actions).
+More information can be found on [our guide for making Direct Upload deployments with continuous integration](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#use-github-actions).
 
 ### Specifying a branch
 


### PR DESCRIPTION
It was unclear that the `branch` option must be set to `main` for the uploaded build to be put into the production environment when using a branch other than `main` for production. Additionally, it is not clear what other values would trigger a build to be put into the production environment. 

Fixed tiny typo, `continuous` was missing a `u`