### PR TITLE
README improvement: Get account ID Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,17 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
 
 ### Get account ID
 
-To find your account ID, log in to the Cloudflare dashboard > select your zone in Account Home > find your account ID in Overview under **API** on the right-side menu. If you have not added a zone, add one by selecting **Add site** . You can purchase a domain from [Cloudflare’s registrar](https://developers.cloudflare.com/registrar/).
+To find your account ID:
 
-If you do not have a zone registered to your account, you can also get your account ID from the `pages.dev` URL. E.g: `https://dash.cloudflare.com/<ACCOUNT_ID>/pages`
+1. Log in to the Cloudflare dashboard
+2. Select your zone in Account Home
+3. Find your account ID in Overview under **API** on the right-side menu
+
+#### If you have not added a zone
+Add one by selecting **Add site** . You can purchase a domain from [Cloudflare’s registrar](https://developers.cloudflare.com/registrar/)
+
+#### If you do not have a zone registered to your account
+You can also get your account ID from the `pages.dev` URL. E.g: `https://dash.cloudflare.com/<ACCOUNT_ID>/pages`
 
 ### Generate an API Token
 


### PR DESCRIPTION
# Problem
- When reading through the documentation there were a lot of steps blended into a single paragraph, making it difficult for new users to follow along

# Proposed Solution (What this PR does)
- This breaks the "Get Account ID" section into pieces to make it more readable by a new user (similar to the "Generate API Token" section)