### PR TITLE
Create GitHub deployment using correct branch name

### DIFF
--- a/index.js
+++ b/index.js
@@ -22095,11 +22095,12 @@ try {
     } = await response.json();
     return deployment;
   };
+  const githubBranch = import_process.env.GITHUB_HEAD_REF || import_process.env.GITHUB_REF_NAME;
   const createGitHubDeployment = async (octokit, productionEnvironment, environment) => {
     const deployment = await octokit.rest.repos.createDeployment({
       owner: import_github.context.repo.owner,
       repo: import_github.context.repo.repo,
-      ref: import_github.context.ref,
+      ref: githubBranch || import_github.context.ref,
       auto_merge: false,
       description: "Cloudflare Pages",
       required_contexts: [],
@@ -22156,7 +22157,6 @@ try {
     const project = await getProject();
     if (!project)
       throw new Error("Unable to find pages project");
-    const githubBranch = import_process.env.GITHUB_REF_NAME;
     const productionEnvironment = githubBranch === project.production_branch;
     const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
     let gitHubDeployment;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,13 @@ try {
 		return deployment;
 	};
 
+	const githubBranch = env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME;
+
 	const createGitHubDeployment = async (octokit: Octokit, productionEnvironment: boolean, environment: string) => {
 		const deployment = await octokit.rest.repos.createDeployment({
 			owner: context.repo.owner,
 			repo: context.repo.repo,
-			ref: context.ref,
+			ref: githubBranch || context.ref,
 			auto_merge: false,
 			description: "Cloudflare Pages",
 			required_contexts: [],
@@ -125,7 +127,6 @@ try {
 		const project = await getProject();
 		if (!project) throw new Error("Unable to find pages project");
 
-		const githubBranch = env.GITHUB_REF_NAME;
 		const productionEnvironment = githubBranch === project.production_branch;
 		const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
 


### PR DESCRIPTION
This replaces #56 and re-fixes #22/#39.

#56 was reverted because it turned out some users enable GitHub deployments _and_ use fake branch names when deploying to Cloudflare Pages. When #56 was released, those users began to experience errors (#67).

This PR takes a simpler approach, ignoring user input and using the real GitHub branch name.