### PR TITLE
Add bundle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloudflare Pages GitHub Action
+ # Cloudflare Pages GitHub Action
 
 GitHub Action for creating Cloudflare Pages deployments, using the new [Direct Upload](https://developers.cloudflare.com/pages/platform/direct-upload/) feature and [Wrangler](https://developers.cloudflare.com/pages/platform/direct-upload/#wrangler-cli) integration.
 
@@ -75,6 +75,10 @@ manually by adding the argument `branch: YOUR_BRANCH_NAME`.
 ### Specifying a working directory
 
 By default Wrangler will run in the root package directory. If your app lives in a monorepo and you want to run Wrangler from its directory, add `workingDirectory: YOUR_PACKAGE_DIRECTORY`.
+
+### Bundling
+
+When using [Advanced mode](https://developers.cloudflare.com/pages/platform/functions/advanced-mode/) Pages Functions will by default bundle your `_worker.js` file. If you want to disable this, add `bundle: false`.
 
 ### Wrangler v3
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: "The version of Wrangler to use"
     required: false
     default: "2"
+  bundle:
+    description: "Whether to run bundling on `_worker.js` before deploying"
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -2071,7 +2071,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput2(name, options);
@@ -2082,7 +2082,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports.getBooleanInput = getBooleanInput;
+    exports.getBooleanInput = getBooleanInput2;
     function setOutput2(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -22070,6 +22070,7 @@ try {
   const branch = (0, import_core.getInput)("branch", { required: false });
   const workingDirectory = (0, import_core.getInput)("workingDirectory", { required: false });
   const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false });
+  const bundle = (0, import_core.getBooleanInput)("bundle", { required: false });
   const getProject = async () => {
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}`,
@@ -22093,8 +22094,8 @@ try {
     if ${accountId} {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
-  
-    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+
+    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}" ${bundle ? "" : "--no-bundle"}
     `;
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getInput, setOutput, setFailed, summary } from "@actions/core";
+import { getInput, getBooleanInput, setOutput, setFailed, summary } from "@actions/core";
 import type { Project, Deployment } from "@cloudflare/types";
 import { context, getOctokit } from "@actions/github";
 import shellac from "shellac";
@@ -17,6 +17,7 @@ try {
 	const branch = getInput("branch", { required: false });
 	const workingDirectory = getInput("workingDirectory", { required: false });
 	const wranglerVersion = getInput("wranglerVersion", { required: false });
+	const bundle = getBooleanInput("bundle", { required: false });
 
 	const getProject = async () => {
 		const response = await fetch(
@@ -45,8 +46,8 @@ try {
     if ${accountId} {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
-  
-    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+
+    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}" ${bundle ? "" : "--no-bundle"}
     `;
 
 		const response = await fetch(


### PR DESCRIPTION
When uploading `_worker.js` source maps to Sentry the automatic bundling of the worker code will make the source maps inaccurate.

This adds a `bundle` option (default `true`) which will allow you to prevent bundling and have the `_worker.js` code be uploaded as is, with intact source maps.