### PR TITLE
Add wranglerVersion options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   workingDirectory:
     description: "The working directory in which to run Wrangler"
     required: false
+  wranglerVersion:
+    description: "The version of Wrangler to use"
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ inputs:
   wranglerVersion:
     description: "The version of Wrangler to use"
     required: false
+    default: 2
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -22069,7 +22069,7 @@ try {
   const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: false });
   const branch = (0, import_core.getInput)("branch", { required: false });
   const workingDirectory = (0, import_core.getInput)("workingDirectory", { required: false });
-  const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false }) ? (0, import_core.getInput)("wranglerVersion", { required: false }) : "2";
+  const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false });
   const getProject = async () => {
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}`,

--- a/index.js
+++ b/index.js
@@ -22069,6 +22069,7 @@ try {
   const gitHubToken = (0, import_core.getInput)("gitHubToken", { required: false });
   const branch = (0, import_core.getInput)("branch", { required: false });
   const workingDirectory = (0, import_core.getInput)("workingDirectory", { required: false });
+  const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false }) ? (0, import_core.getInput)("wranglerVersion", { required: false }) : "2";
   const getProject = async () => {
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}`,
@@ -22084,7 +22085,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,7 @@ try {
 	const gitHubToken = getInput("gitHubToken", { required: false });
 	const branch = getInput("branch", { required: false });
 	const workingDirectory = getInput("workingDirectory", { required: false });
-	const wranglerVersion = getInput("wranglerVersion", { required: false })
-		? getInput("wranglerVersion", { required: false })
-		: "2";
+	const wranglerVersion = getInput("wranglerVersion", { required: false });
 
 	const getProject = async () => {
 		const response = await fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ try {
 	const gitHubToken = getInput("gitHubToken", { required: false });
 	const branch = getInput("branch", { required: false });
 	const workingDirectory = getInput("workingDirectory", { required: false });
+	const wranglerVersion = getInput("wranglerVersion", { required: false })
+		? getInput("wranglerVersion", { required: false })
+		: "2";
 
 	const getProject = async () => {
 		const response = await fetch(
@@ -34,7 +37,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@2 pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
 
 		const response = await fetch(
@@ -93,7 +96,7 @@ try {
 			log_url: `https://dash.cloudflare.com/${accountId}/pages/view/${projectName}/${deploymentId}`,
 			description: "Cloudflare Pages",
 			state: "success",
-			auto_inactive: false
+			auto_inactive: false,
 		});
 	};
 


### PR DESCRIPTION
There is an issue with the cloudflare/next-on-pages library that causes a "Script startup exceeded CPU time limit" error after using the publish command. This issue has been fixed in https://github.com/cloudflare/next-on-pages/issues/54. However, currently only the publish command from wrangler@2.16.0 version can run properly, so I need the wranglerVersion feature.