### PR TITLE
chore: exclude md from tab indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ end_of_line = lf
 indent_style = tab
 tab_width = 2
 
-[*.yml]
+[*.{yml,md}]
 indent_style = space


### PR DESCRIPTION
This prevents `yaml` codeblocks in markdown files from being converted to tabs, which doesn't work.

Context: https://github.com/cloudflare/pages-action/pull/91