### PR TITLE
chore: improve clarity in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
              accountId: YOUR_ACCOUNT_ID
              projectName: YOUR_PROJECT_NAME
-             directory: YOUR_ASSET_DIRECTORY
+             directory: YOUR_BUILD_OUTPUT_DIRECTORY
              # Optional: Enable this if you want to have GitHub Deployments triggered
              gitHubToken: ${{ secrets.GITHUB_TOKEN }}
              # Optional: Switch what branch you are publishing to.
@@ -42,7 +42,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              wranglerVersion: '3'
    ```
 
-1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_ASSET_DIRECTORY` with the appropriate values to your Pages project.
+1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_BUILD_OUTPUT_DIRECTORY` with the appropriate values to your Pages project.
 
 ### Get account ID
 
@@ -87,7 +87,7 @@ You can use the newly released [Wrangler v3](https://blog.cloudflare.com/wrangle
       apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       accountId: YOUR_ACCOUNT_ID
       projectName: YOUR_PROJECT_NAME
-      directory: YOUR_ASSET_DIRECTORY
+      directory: YOUR_BUILD_OUTPUT_DIRECTORY
       # Enable Wrangler v3
       wranglerVersion: '3'
 ```


### PR DESCRIPTION
## About

This PR changes references of `YOUR_ASSET_DIRECTORY` to `YOUR_BUILD_OUTPUT_DIRECTORY` in the `README` file in the root of this repository.

## Why

1. `YOUR_ASSET_DIRECTORY` may be interpreted with a project's static assets directory instead of the build directory used when building the project. If this happens, debugging is painstaking.

2. Cloudflare mentioned `Build output directory` on their web front. Using the same terminology is advised:

   ![image](https://github.com/cloudflare/pages-action/assets/13122796/c3e39aee-90f7-451b-b4b6-09cd040c46ed)