### PR TITLE
Add includeLogs option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "The version of Wrangler to use"
     required: false
     default: "2"
+  includeLogs:
+    description: "Include logs from failed deployments in the deployment summary"
+    required: false
+    default: "false"
 runs:
   using: "node16"
   main: "index.js"


### PR DESCRIPTION
Wanted a way to show logs to developers without providing CF console access since there's no role for pages only nor read only pages deployments role.