### PR TITLE
Allow the user to override the environmentName

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ GitHub Action for creating Cloudflare Pages deployments, using the new [Direct U
              # Optional: Change the working directory
              workingDirectory: my-site
              # Optional: Change the Wrangler version, allows you to point to a specific version or a tag such as `beta`
-             wranglerVersion: '3'
+             wranglerVersion: "3"
    ```
 
 1. Replace `YOUR_ACCOUNT_ID`, `YOUR_PROJECT_NAME` and `YOUR_BUILD_OUTPUT_DIRECTORY` with the appropriate values to your Pages project.
@@ -81,15 +81,15 @@ By default Wrangler will run in the root package directory. If your app lives in
 You can use the newly released [Wrangler v3](https://blog.cloudflare.com/wrangler3/) with the `wranglerVersion` property.
 
 ```yaml
-  - name: Publish to Cloudflare Pages
-    uses: cloudflare/pages-action@v1
-    with:
-      apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      accountId: YOUR_ACCOUNT_ID
-      projectName: YOUR_PROJECT_NAME
-      directory: YOUR_BUILD_OUTPUT_DIRECTORY
-      # Enable Wrangler v3
-      wranglerVersion: '3'
+- name: Publish to Cloudflare Pages
+  uses: cloudflare/pages-action@v1
+  with:
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    accountId: YOUR_ACCOUNT_ID
+    projectName: YOUR_PROJECT_NAME
+    directory: YOUR_BUILD_OUTPUT_DIRECTORY
+    # Enable Wrangler v3
+    wranglerVersion: "3"
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: "The version of Wrangler to use"
     required: false
     default: "2"
+  environmentName:
+    description: "Override the environment name to use"
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -22070,6 +22070,7 @@ try {
   const branch = (0, import_core.getInput)("branch", { required: false });
   const workingDirectory = (0, import_core.getInput)("workingDirectory", { required: false });
   const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false });
+  const environmentName = (0, import_core.getInput)("environmentName", { required: false });
   const getProject = async () => {
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}`,
@@ -22125,7 +22126,7 @@ try {
     id,
     url,
     deploymentId,
-    environmentName,
+    environmentName: environmentName2,
     productionEnvironment,
     octokit
   }) => {
@@ -22133,7 +22134,7 @@ try {
       owner: import_github.context.repo.owner,
       repo: import_github.context.repo.repo,
       deployment_id: id,
-      environment: environmentName,
+      environment: environmentName2,
       environment_url: url,
       production_environment: productionEnvironment,
       log_url: `https://dash.cloudflare.com/${accountId}/pages/view/${projectName}/${deploymentId}`,
@@ -22166,11 +22167,11 @@ try {
   (async () => {
     const project = await getProject();
     const productionEnvironment = githubBranch === project.production_branch || branch === project.production_branch;
-    const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
+    const cfEnvironmentName = environmentName ? environmentName : `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
     let gitHubDeployment;
     if (gitHubToken && gitHubToken.length) {
       const octokit = (0, import_github.getOctokit)(gitHubToken);
-      gitHubDeployment = await createGitHubDeployment(octokit, productionEnvironment, environmentName);
+      gitHubDeployment = await createGitHubDeployment(octokit, productionEnvironment, cfEnvironmentName);
     }
     const pagesDeployment = await createPagesDeployment();
     (0, import_core.setOutput)("id", pagesDeployment.id);
@@ -22188,7 +22189,7 @@ try {
         id: gitHubDeployment.id,
         url: pagesDeployment.url,
         deploymentId: pagesDeployment.id,
-        environmentName,
+        environmentName: cfEnvironmentName,
         productionEnvironment,
         octokit
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ try {
 	const branch = getInput("branch", { required: false });
 	const workingDirectory = getInput("workingDirectory", { required: false });
 	const wranglerVersion = getInput("wranglerVersion", { required: false });
+	const environmentName = getInput("environmentName", { required: false });
 
 	const getProject = async () => {
 		const response = await fetch(
@@ -139,13 +140,15 @@ try {
 		const project = await getProject();
 
 		const productionEnvironment = githubBranch === project.production_branch || branch === project.production_branch;
-		const environmentName = `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
+		const cfEnvironmentName = environmentName
+			? environmentName
+			: `${projectName} (${productionEnvironment ? "Production" : "Preview"})`;
 
 		let gitHubDeployment: Awaited<ReturnType<typeof createGitHubDeployment>>;
 
 		if (gitHubToken && gitHubToken.length) {
 			const octokit = getOctokit(gitHubToken);
-			gitHubDeployment = await createGitHubDeployment(octokit, productionEnvironment, environmentName);
+			gitHubDeployment = await createGitHubDeployment(octokit, productionEnvironment, cfEnvironmentName);
 		}
 
 		const pagesDeployment = await createPagesDeployment();
@@ -168,7 +171,7 @@ try {
 				id: gitHubDeployment.id,
 				url: pagesDeployment.url,
 				deploymentId: pagesDeployment.id,
-				environmentName,
+				environmentName: cfEnvironmentName,
 				productionEnvironment,
 				octokit,
 			});


### PR DESCRIPTION
This change allows the user to override the environmentName of the deployed environment reported to github. This affects what is shown on the repo page and PR timeline items.

* Allow the user to override the environmentName
* Run `npm run prettify`