### PR TITLE
Add action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,15 @@ inputs:
     description: "The version of Wrangler to use"
     required: false
     default: "2"
+outputs:
+  id:
+    description: The ID of the pages deployment
+  url:
+    description: The URL of the pages deployment
+  alias:
+    description: The alias if it exists otherwise the deployment URL
+  environment: 
+    description: The environment that was deployed to
 runs:
   using: "node16"
   main: "index.js"


### PR DESCRIPTION
This PR add an `outputs` field to the `action.yml` metadata file.
This field is not required, but with it some code editors (like [**VSCode**](https://code.visualstudio.com) with  the [**GitHub Actions**](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions) extension, for example) gain the ability to provide autocomplete for `${{ steps.<id>.outputs.<output_name> }}`.

For more information, please see [**Outputs for JavaScript actions**](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions).