### PR TITLE
upgraded to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: false
     default: "2"
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
Upgraded to node20 to get rid of following warning:

```Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, cloudflare/pages-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.```