### PR TITLE
Added support for different package managers

### DIFF
--- a/index.js
+++ b/index.js
@@ -22070,6 +22070,7 @@ try {
   const branch = (0, import_core.getInput)("branch", { required: false });
   const workingDirectory = (0, import_core.getInput)("workingDirectory", { required: false });
   const wranglerVersion = (0, import_core.getInput)("wranglerVersion", { required: false });
+  const packageManager = (0, import_core.getInput)("packageManager", { required: false });
   const getProject = async () => {
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}`,
@@ -22088,13 +22089,19 @@ try {
     return result;
   };
   const createPagesDeployment = async () => {
+    let packageRunner = "npx";
+    if (packageManager === "pnpm") {
+      packageRunner = "pnpm dlx";
+    } else if (packageManager === "bun") {
+      packageRunner = "bunx";
+    }
     await src_default.in(import_node_path.default.join(process.cwd(), workingDirectory))`
     $ export CLOUDFLARE_API_TOKEN="${apiToken}"
     if ${accountId} {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+    $$ ${packageRunner} wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
     const response = await (0, import_undici.fetch)(
       `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ try {
 	const branch = getInput("branch", { required: false });
 	const workingDirectory = getInput("workingDirectory", { required: false });
 	const wranglerVersion = getInput("wranglerVersion", { required: false });
+	const packageManager = getInput("packageManager", { required: false });
 
 	const getProject = async () => {
 		const response = await fetch(
@@ -39,6 +40,13 @@ try {
 	};
 
 	const createPagesDeployment = async () => {
+		let packageRunner = "npx"
+		if(packageManager === "pnpm") {
+			packageRunner = "pnpm dlx"
+		} else if (packageManager === "bun") {
+			packageRunner = "bunx"			
+		}
+
 		// TODO: Replace this with an API call to wrangler so we can get back a full deployment response object
 		await shellac.in(path.join(process.cwd(), workingDirectory))`
     $ export CLOUDFLARE_API_TOKEN="${apiToken}"
@@ -46,7 +54,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+    $$ ${packageRunner} wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
 
 		const response = await fetch(


### PR DESCRIPTION
I added a new `packageManager` option field that allows the developer to choose which package manager to use to run wrangler.

Currently I've added support for `pnpm` and `bun` using `pnpm dlx` and `bunx` respectively, the default is `npx` in any other case.

The motivation for adding this is avoiding `npm` to install the wrangler dependency if it's not present. Instead of using `npm` it will now use the specified package manager, maintaining consistency with the previous steps of the developers action.