### PR TITLE
Specify production branch

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -18,6 +18,8 @@ jobs:
           projectName: github-actions-example
           directory: example
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          productionBranch: main
         id: publish
       - name: Outputs
         run: |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: false
+  productionBranch:
+    description: "The name of the branch you want to deploy to production"
+    required: true
   branch:
     description: "The name of the branch you want to deploy to"
     required: false

--- a/index.js
+++ b/index.js
@@ -22072,7 +22072,7 @@ var generateURL = (branch, URL2) => {
     return "";
   }
   const url = URL2.split(".");
-  url[0] = "https://" + branch;
+  url[0] = "https://" + generatedBranch;
   return url.join(".");
 };
 function generateBranchAlias(branch) {

--- a/src/generateAlias.ts
+++ b/src/generateAlias.ts
@@ -13,7 +13,7 @@ export const generateURL = (branch: string, URL: string): string => {
         return ""
     }
     const url = URL.split(".");
-    url[0] = "https://" + branch;
+    url[0] = "https://" + generatedBranch;
     return url.join(".")
 }
 function generateBranchAlias(branch: string): string | undefined {

--- a/src/generateAlias.ts
+++ b/src/generateAlias.ts
@@ -1,0 +1,61 @@
+// Author: Daniel Walsh (https://github.com/WalshyDev)
+// Source: https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633/2
+// License: ?
+//
+// Modified by: Michael Schnerring
+
+const invalidCharsRegex = /[^a-z0-9-]/g
+const maxAliasLength = 28
+const alphanum = 'abcdefghijklmnopqrstuvwxyz0123456789'
+export const generateURL = (branch: string, URL: string): string => {
+    const generatedBranch = generateBranchAlias(branch)
+    if (!generatedBranch) {
+        return ""
+    }
+    const url = URL.split(".");
+    url[0] = "https://" + branch;
+    return url.join(".")
+}
+function generateBranchAlias(branch: string): string | undefined {
+    let normalised = branch.toLowerCase().replace(invalidCharsRegex, '-')
+
+    if (normalised.length > maxAliasLength) {
+        normalised = normalised.substring(0, maxAliasLength)
+    }
+
+    normalised = trim(normalised, '-')
+
+    if (normalised === '') {
+        return `branch-${randAlphaNum(10)}`
+    }
+
+    return normalised
+}
+
+function trim(str: string, char: string): string {
+    while (str.startsWith(char)) {
+        if (str.length === 1) {
+            return ''
+        }
+        str = str.substring(1)
+    }
+
+    while (str.endsWith(char)) {
+        if (str.length === 1) {
+            return ''
+        }
+        str = str.substring(0, str.length - 1)
+    }
+
+    return str
+}
+
+function randAlphaNum(length: number): string {
+    let result = ''
+
+    for (let i = 0; i < length; i++) {
+        result += alphanum[Math.floor(Math.random() * alphanum.length)]
+    }
+
+    return result
+}


### PR DESCRIPTION
# Problem
Our team uses Cloudflare Pages, and we need to get an alias URL for our develop branch. However, our project has set the default branch to develop, instead of the main production branch, to prevent accidental PRs to the production branch.

The current implementation seems to recognize the production branch based on whether it is the default branch or not. As a result, we are unable to get an alias URL for our develop branch.

# Solution
To address this issue, I have implemented a feature that allows users to explicitly specify the production branch. This gives us more control and flexibility in managing our deployment workflow, even when the default branch is not the production branch.


To generate the sanitized branch name for the alias URL, I used the code from [this GitHub repository](https://github.com/schnerring/cloudflare-pages-branch-alias-action/blob/main/src/generate-branch-alias.ts). This code is based on [this discussion](https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633) in the Cloudflare community forums.

The branch name sanitization process ensures that the generated alias URL conforms to the required format and does not include any invalid characters or patterns.

 As this is my first Pull Request, I would appreciate any guidance or suggestions to improve the quality of my contribution.