### PR TITLE
Set GitHub default token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
   gitHubToken:
     description: "GitHub Token"
     required: false
+    default: ${{ github.token }}
   branch:
     description: "The name of the branch you want to deploy to"
     required: false


### PR DESCRIPTION
This will allow the user to skip setting up the `gitHubToken` parameter in the action.