### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -9,7 +9,7 @@ jobs:
     name: Example
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Publish to Cloudflare Pages
         uses: ./
         with:


### PR DESCRIPTION
Old ones based on Node 16 are deprecated.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20