### PR TITLE
Fix deprecated “publish” command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ try {
       $ export CLOUDFLARE_ACCOUNT_ID="${accountId}"
     }
   
-    $$ npx wrangler@${wranglerVersion} pages publish "${directory}" --project-name="${projectName}" --branch="${branch}"
+    $$ npx wrangler@${wranglerVersion} pages deploy "${directory}" --project-name="${projectName}" --branch="${branch}"
     `;
 
 		const response = await fetch(


### PR DESCRIPTION
```
`wrangler pages publish` is deprecated and will be removed in the next major version.

  Please use `wrangler pages deploy` instead
```
Warning fixed